### PR TITLE
Pass GH org and repo by ID rather than name

### DIFF
--- a/modules/github_ci_infra/main.tf
+++ b/modules/github_ci_infra/main.tf
@@ -16,18 +16,6 @@ resource "random_id" "default" {
   byte_length = 2
 }
 
-data "github_organization" "org" {
-  # We only use the GitHub organization for it's ID number. This only works if the owner is an
-  # organization though (not if it's a person). Therefore, we make this lookup conditional. If
-  # the owner is a person, then the caller can provide the owner ID, and this lookup will be
-  # skipped.
-  count = var.github_owner_id == null ? 1 : 0
-  name = var.github_owner_name
-}
-
-data "github_repository" "repo" {
-  full_name = "${var.github_owner_name}/${var.github_repository_name}"
-}
 
 # Project Services
 resource "google_project_service" "services" {
@@ -84,7 +72,7 @@ resource "google_iam_workload_identity_pool_provider" "github_provider" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.github_pool.workload_identity_pool_id
   workload_identity_pool_provider_id = "github-provider"
   display_name                       = "GitHub WIF Provider"
-  description                        = "GitHub OIDC identity provider for ${data.github_repository.repo.full_name} CI environment"
+  description                        = "GitHub OIDC identity provider for GitHub repo ${var.github_repository_id} CI environment"
   attribute_mapping = {
     "google.subject" : "assertion.sub"
     "attribute.actor" : "assertion.actor"
@@ -101,7 +89,7 @@ resource "google_iam_workload_identity_pool_provider" "github_provider" {
   #
   # We also prevent pull_request_target, since that runs arbitrary code:
   #   https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-  attribute_condition = "attribute.event_name != \"pull_request_target\" && attribute.repository_owner_id == \"${var.github_owner_id != null ? var.github_owner_id : data.github_organization.org[0].id}\" && attribute.repository_id == \"${data.github_repository.repo.repo_id}\""
+  attribute_condition = "attribute.event_name != \"pull_request_target\" && attribute.repository_owner_id == \"${var.github_owner_id}\" && attribute.repository_id == \"${var.github_repository_id}\""
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"

--- a/modules/github_ci_infra/main.tf
+++ b/modules/github_ci_infra/main.tf
@@ -17,7 +17,11 @@ resource "random_id" "default" {
 }
 
 data "github_organization" "org" {
-  count = var.github_owner_id == null ? 1 : 0 # Only look up ID if it's not provided
+  # We only use the GitHub organization for it's ID number. This only works if the owner is an
+  # organization though (not if it's a person). Therefore, we make this lookup conditional. If
+  # the owner is a person, then the caller can provide the owner ID, and this lookup will be
+  # skipped.
+  count = var.github_owner_id == null ? 1 : 0
   name = var.github_owner_name
 }
 

--- a/modules/github_ci_infra/variables.tf
+++ b/modules/github_ci_infra/variables.tf
@@ -31,6 +31,12 @@ variable "github_owner_name" {
   description = "The GitHub owner name to grant access to the WIF pool GitHub provider (e.g. organization)."
 }
 
+variable "github_owner_id" {
+  type = string
+  default = null
+  description = "The GitHub owner ID to grant access to the WIF pool. This can be omitted if github_owner_name is an organization. Otherwise, (say if github_owner_name is a username and not an org), then this must be provided. It can be found at https://api.github.com/users/$USERNAME ."
+}
+
 variable "github_repository_name" {
   type        = string
   description = "The GitHub repository name to grant access to the WIF pool GitHub provider (e.g. repo-name)."

--- a/modules/github_ci_infra/variables.tf
+++ b/modules/github_ci_infra/variables.tf
@@ -26,20 +26,14 @@ variable "name" {
   }
 }
 
-variable "github_owner_name" {
-  type        = string
-  description = "The GitHub owner name to grant access to the WIF pool GitHub provider (e.g. organization)."
-}
-
 variable "github_owner_id" {
-  type = string
-  default = null
-  description = "The GitHub owner ID to grant access to the WIF pool. This can be omitted if github_owner_name is an organization. Otherwise, (say if github_owner_name is a username and not an org), then this must be provided. It can be found at https://api.github.com/users/$USERNAME ."
+  type = number
+  description = "The GitHub ID of the owner of the repository whose workflows will be granted access to the WIF pool (i.e. an organization ID or user ID)."
 }
 
-variable "github_repository_name" {
-  type        = string
-  description = "The GitHub repository name to grant access to the WIF pool GitHub provider (e.g. repo-name)."
+variable "github_repository_id" {
+  type        = number
+  description = "The GitHub ID of the repository whose workflows will be granted access to the WIF pool."
 }
 
 variable "registry_repository_id" {

--- a/modules/github_ci_infra/variables.tf
+++ b/modules/github_ci_infra/variables.tf
@@ -27,7 +27,7 @@ variable "name" {
 }
 
 variable "github_owner_id" {
-  type = number
+  type        = number
   description = "The GitHub ID of the owner of the repository whose workflows will be granted access to the WIF pool (i.e. an organization ID or user ID)."
 }
 


### PR DESCRIPTION
Why: prior to this, this module wouldn't work with repos that are part of a personal GitHub account, only those that are part of an organization. This makes it hard to test integrating with this module

This is a bit of a hack, since it uses the terraform `count` mechanism nonintuitively to only load the org data if the owner_id isn't provided.

Alternative considered: just skip the org lookup altogether and require the caller to provide the owner ID. This sounds good to me, but we have to migrate anyone who's using this module.