### PR TITLE
Output GAR repo ID and location

### DIFF
--- a/modules/github_ci_infra/outputs.tf
+++ b/modules/github_ci_infra/outputs.tf
@@ -17,6 +17,16 @@ output "artifact_repository_name" {
   value       = google_artifact_registry_repository.artifact_repository.name
 }
 
+output "artifact_repository_id" {
+  description = "The Artifact Registry ID, e.g. ci-images"
+  value       = google_artifact_registry_repository.artifact_repository.repository_id
+}
+
+output "artifact_repository_location" {
+  description = "The Artifact Registry repository location, e.g. \"us\" or \"us-west1\""
+  value       = google_artifact_registry_repository.artifact_repository.location
+}
+
 output "wif_pool_name" {
   description = "The Workload Identity Federation pool name."
   value       = google_iam_workload_identity_pool.github_pool.name


### PR DESCRIPTION
This allows callers to easily build IAM bindings for the GAR repo.

Responding to anticipated objections:

Q: the GAR repo ID and name are inputs, so the user should already know their values.
A: Not if they're using the default variable values.

Q: Isn't this information already available in the full/name/with/slashes?
A: Parsing it would be gross.

Q: Does the caller really need to know this?
A: Yes. Cloud Run Service Agents need read access to the GAR repo.