### PR TITLE
Make oauth2_client_secret_sha256 a optional string

### DIFF
--- a/modules/gclb_cloud_run_backend/main.tf
+++ b/modules/gclb_cloud_run_backend/main.tf
@@ -146,7 +146,6 @@ resource "google_compute_backend_service" "default" {
     content {
       oauth2_client_id            = var.iap_config.oauth2_client_id
       oauth2_client_secret        = var.iap_config.oauth2_client_secret
-      oauth2_client_secret_sha256 = var.iap_config.oauth2_client_secret_sha256
     }
   }
 }

--- a/modules/gclb_cloud_run_backend/main.tf
+++ b/modules/gclb_cloud_run_backend/main.tf
@@ -144,8 +144,8 @@ resource "google_compute_backend_service" "default" {
   dynamic "iap" {
     for_each = var.iap_config.enable ? [1] : []
     content {
-      oauth2_client_id            = var.iap_config.oauth2_client_id
-      oauth2_client_secret        = var.iap_config.oauth2_client_secret
+      oauth2_client_id     = var.iap_config.oauth2_client_id
+      oauth2_client_secret = var.iap_config.oauth2_client_secret
     }
   }
 }

--- a/modules/gclb_cloud_run_backend/variables.tf
+++ b/modules/gclb_cloud_run_backend/variables.tf
@@ -50,14 +50,14 @@ variable "security_policy" {
 
 variable "iap_config" {
   type = object({
-    enable                      = bool
-    oauth2_client_id            = string
-    oauth2_client_secret        = string
+    enable               = bool
+    oauth2_client_id     = string
+    oauth2_client_secret = string
   })
   default = {
-    enable                      = false
-    oauth2_client_id            = ""
-    oauth2_client_secret        = ""
+    enable               = false
+    oauth2_client_id     = ""
+    oauth2_client_secret = ""
   }
   description = "Identity-Aware Proxy configuration for the load balancer."
 }

--- a/modules/gclb_cloud_run_backend/variables.tf
+++ b/modules/gclb_cloud_run_backend/variables.tf
@@ -53,13 +53,11 @@ variable "iap_config" {
     enable                      = bool
     oauth2_client_id            = string
     oauth2_client_secret        = string
-    oauth2_client_secret_sha256 = optional(string)
   })
   default = {
     enable                      = false
     oauth2_client_id            = ""
     oauth2_client_secret        = ""
-    oauth2_client_secret_sha256 = ""
   }
   description = "Identity-Aware Proxy configuration for the load balancer."
 }

--- a/modules/gclb_cloud_run_backend/variables.tf
+++ b/modules/gclb_cloud_run_backend/variables.tf
@@ -53,7 +53,7 @@ variable "iap_config" {
     enable                      = bool
     oauth2_client_id            = string
     oauth2_client_secret        = string
-    oauth2_client_secret_sha256 = string
+    oauth2_client_secret_sha256 = optional(string)
   })
   default = {
     enable                      = false


### PR DESCRIPTION
I attempted to leverage the [iap_config](https://github.com/abcxyz/terraform-modules/blob/main/modules/gclb_cloud_run_backend/variables.tf#L51) to associate IAP with a load balancer. The `oauth2_client_secret_sha256` field was set to required but the [iap client resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_client) does not export this attribute. I tried to use the terraform sha256 method on the actual clientId but that also does not work (I didnt think it would but tried it anyway).  

Without this change this is the error received 
```
Can't configure a value for "iap.0.oauth2_client_secret_sha256": its value will be decided automatically based on the result of applying this configuration.
```

By making this value optional and only passing the `oauth2_client_id` and `oauth2_client_secret`, it becomes valid. This indicates to me that IAP instance will associate to the load balancer. If im missing something obvious, please let me know!