### PR TITLE
Ignore the commit-sha and managed-by labels

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -146,6 +146,8 @@ resource "google_cloud_run_service" "service" {
       metadata[0].annotations["serving.knative.dev/creator"],
       metadata[0].annotations["serving.knative.dev/lastModifier"],
       metadata[0].labels["cloud.googleapis.com/location"],
+      metadata[0].labels["commit-sha"],
+      metadata[0].labels["managed-by"],
       template[0].metadata[0].annotations["client.knative.dev/user-image"],
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],


### PR DESCRIPTION
Currently, terraform wants to reset these every time you deploy your service outside of terraform. This is unnecessary, slow, and irritating.