### PR TITLE
Fix README example

### DIFF
--- a/modules/github_ci_infra/README.md
+++ b/modules/github_ci_infra/README.md
@@ -6,9 +6,11 @@ This module provides the default Google Cloud infrastructre used by GitHub CI fo
 
 ```terraform
 module "github_ci_infra" {
-  source                 = "https://github.com/abcxyz/infra/terraform/modules/github_ci_infra"
-  project_id             = "my-project-id"
-  name                   = "project-name"
-  github_repository_name = "repo-name"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/github_ci_infra?ref=SHA_OR_TAG"
+
+  project_id           = "my-project-id"
+  name                 = "project-name"
+  github_owner_id      = 123456
+  github_repository_id = 123456789
 }
 ```


### PR DESCRIPTION
Earlier I changed the arguments to this module but forgot to fix the example.

I also switched from `https://...` to `git::https://...` which is the preferred style for abcxyz.