### PR TITLE
Convert from GitHub secrets to variables now that TF supports them

### DIFF
--- a/examples/cloudrun_cicd/main.tf
+++ b/examples/cloudrun_cicd/main.tf
@@ -313,18 +313,6 @@ resource "google_service_account_iam_member" "impersonate" {
   member             = module.github_ci_access_config.service_account_member
 }
 
-# Set repository-level secrets on the GitHub repo that can be used by CI/CD workflows.
-module "github_vars" {
-  source = "git::https://github.com/abcxyz/terraform-modules/modules/github_cicd_workflow_vars?ref=SHA_OR_TAG_HERE"
-
-  infra_project_id             = local.infra_project_id
-  github_repository_name       = local.github_repository_name
-  wif_provider_name            = module.github_ci_access_config.wif_provider_name
-  service_account_email        = module.github_ci_access_config.service_account_email
-  artifact_repository_id       = module.github_ci_access_config.artifact_repository_id
-  artifact_repository_location = module.github_ci_access_config.artifact_repository_location
-}
-
 resource "github_repository_environment" "default" {
   for_each = local.environments
 
@@ -348,4 +336,21 @@ resource "github_repository_environment" "default" {
       custom_branch_policies = each.value.github.deployment_branch_policy.custom_branch_policies
     }
   }
+}
+
+# Set repository-level secrets on the GitHub repo that can be used by CI/CD workflows.
+module "github_vars" {
+  source = "git::https://github.com/abcxyz/terraform-modules/modules/github_cicd_workflow_vars?ref=SHA_OR_TAG_HERE"
+
+  infra_project_id             = local.infra_project_id
+  github_repository_name       = local.github_repository_name
+  wif_provider_name            = module.github_ci_access_config.wif_provider_name
+  service_account_email        = module.github_ci_access_config.service_account_email
+  artifact_repository_id       = module.github_ci_access_config.artifact_repository_id
+  artifact_repository_location = module.github_ci_access_config.artifact_repository_location
+  environment_projects         = local.serving_project_ids
+
+  depends_on = [
+    github_repository_environment.default
+  ]
 }

--- a/modules/github_cicd_workflow_vars/main.tf
+++ b/modules/github_cicd_workflow_vars/main.tf
@@ -12,32 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "github_actions_secret" "wif_provider_secret" {
-  repository      = var.github_repository_name # Excludes org name, which is implied by the access token.
-  secret_name     = "wif_provider"
-  plaintext_value = var.wif_provider_name
+resource "github_actions_variable" "wif_provider" {
+  repository    = var.github_repository_name # Excludes org name, which is implied by the access token.
+  variable_name = "wif_provider"
+  value         = var.wif_provider_name
 }
 
-resource "github_actions_secret" "wif_service_account_secret" {
-  repository      = var.github_repository_name
-  secret_name     = "wif_service_account"
-  plaintext_value = var.service_account_email
+resource "github_actions_variable" "wif_service_account" {
+  repository    = var.github_repository_name
+  variable_name = "wif_service_account"
+  value         = var.service_account_email
 }
 
-resource "github_actions_secret" "infra_project_id_secret" {
-  repository      = var.github_repository_name
-  secret_name     = "infra_project_id"
-  plaintext_value = var.infra_project_id
+resource "github_actions_variable" "infra_project_id" {
+  repository    = var.github_repository_name
+  variable_name = "infra_project_id"
+  value         = var.infra_project_id
 }
 
-resource "github_actions_secret" "gar_location_secret" {
-  repository      = var.github_repository_name
-  secret_name     = "gar_location"
-  plaintext_value = var.artifact_repository_location
+resource "github_actions_variable" "gar_location" {
+  repository    = var.github_repository_name
+  variable_name = "gar_location"
+  value         = var.artifact_repository_location
 }
 
-resource "github_actions_secret" "gar_repo_id_secret" {
-  repository      = var.github_repository_name
-  secret_name     = "gar_repo_id"
-  plaintext_value = var.artifact_repository_id
+resource "github_actions_variable" "gar_repo_id" {
+  repository    = var.github_repository_name
+  variable_name = "gar_repo_id"
+  value         = var.artifact_repository_id
+}
+
+resource "github_actions_environment_variable" "project_id_for_env" {
+  for_each = var.environment_projects
+
+  repository    = var.github_repository_name
+  variable_name = "project_id_for_env"
+  environment   = each.key
+  value         = each.value
 }

--- a/modules/github_cicd_workflow_vars/variables.tf
+++ b/modules/github_cicd_workflow_vars/variables.tf
@@ -42,3 +42,7 @@ variable "artifact_repository_location" {
   description = "Location of the artifact registry repository. Either a region name or a multi-regional location name. E.g. 'us', 'us-west1'"
 }
 
+variable "environment_projects" {
+  type        = map(string)
+  description = "A map where the keys are GitHub environment names and the values are the GCP project IDs where that environment runs."
+}


### PR DESCRIPTION
Now that the github provider in terraform supports variables, we can use them. This is better because they won't be unnecessarily obfuscated in logs and can be viewed in the web UI for debugging purposes.