### PR TITLE
fix iam delay for product-project-github when adding new environments

### DIFF
--- a/modules/platform/product-project-github/main.tf
+++ b/modules/platform/product-project-github/main.tf
@@ -49,6 +49,8 @@ resource "google_tags_tag_binding" "wif_github" {
 # creating these resources consistently succeed. We will wait 45s for
 # IAM propagation.
 resource "time_sleep" "wait_45s" {
+  for_each = module.projects.environments
+
   create_duration = "45s"
 
   depends_on = [module.projects]


### PR DESCRIPTION
If you add a new environment to an existing product, this is needed so that the creation of the new resources wont fail due to IAM propagation delay.