### PR TITLE
feat: Add HTTP startup probe config to Cloud Run module

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -73,6 +73,18 @@ resource "google_cloud_run_service" "service" {
         image = var.image
         args  = var.args
 
+        dynamic "startup_probe" {
+          for_each = var.startup_probe == {} ? toset([]) : toset([1])
+
+          content {
+            initial_delay_seconds = var.startup_probe.initial_delay_seconds
+            timeout_seconds = var.startup_probe.timeout_seconds
+            period_seconds = var.startup_probe.period_seconds
+            failure_threshold = var.startup_probe.failure_threshold
+            http_get = var.startup_probe.http_get
+          }
+        }
+
         resources {
           requests = var.resources.requests
           limits   = var.resources.limits

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -88,6 +88,16 @@ resource "google_cloud_run_service" "service" {
               content {
                 path = var.startup_probe.http_get.path
                 port = var.startup_probe.http_get.port
+
+                dynamic "http_headers" {
+                  for_each = (
+                    var.startup_probe.http_get.http_headers
+                  )
+                  content {
+                    name  = http_headers.key
+                    value = http_headers.value
+                  }
+                }
               }
             }
           }

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -81,7 +81,13 @@ resource "google_cloud_run_service" "service" {
             timeout_seconds = var.startup_probe.timeout_seconds
             period_seconds = var.startup_probe.period_seconds
             failure_threshold = var.startup_probe.failure_threshold
-            http_get = var.startup_probe.http_get
+
+            dynamic "http_get" {
+              for_each = var.startup_probe.http_get == {} ? toset([]) : toset([1])
+
+              path = var.startup_probe.http_get.path
+              port = var.startup_probe.http_get.port
+            }
           }
         }
 

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -80,7 +80,7 @@ resource "google_cloud_run_service" "service" {
           failure_threshold     = var.startup_probe.failure_threshold
 
           dynamic "http_get" {
-            count = var.startup_probe.http_get != null ? 1 : 0
+            for_each = var.startup_probe.http_get != null ? [1] : [0]
 
             content {
               path = var.startup_probe.http_get.path

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -73,14 +73,18 @@ resource "google_cloud_run_service" "service" {
         image = var.image
         args  = var.args
 
-        startup_probe {
-          initial_delay_seconds = var.startup_probe.initial_delay_seconds
-          timeout_seconds       = var.startup_probe.timeout_seconds
-          period_seconds        = var.startup_probe.period_seconds
-          failure_threshold     = var.startup_probe.failure_threshold
+        dynamic "startup_probe" {
+          for_each = var.startup_probe == null ? [] : [""]
+
+          content {
+            initial_delay_seconds = var.startup_probe.initial_delay_seconds
+            timeout_seconds       = var.startup_probe.timeout_seconds
+            period_seconds        = var.startup_probe.period_seconds
+            failure_threshold     = var.startup_probe.failure_threshold
+          }
 
           dynamic "http_get" {
-            for_each = var.startup_probe.http_get != null ? [1] : [0]
+            for_each = var.startup_probe.http_get == null ? [] : [""]
 
             content {
               path = var.startup_probe.http_get.path

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "service" {
         args  = var.args
 
         dynamic "startup_probe" {
-          for_each = var.startup_probe ? toset([]) : toset([1])
+          for_each = var.startup_probe ? toset([1]) : toset([])
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds
@@ -83,7 +83,7 @@ resource "google_cloud_run_service" "service" {
             failure_threshold = var.startup_probe.failure_threshold
 
             dynamic "http_get" {
-              for_each = var.startup_probe.http_get ? toset([]) : toset([1])
+              for_each = var.startup_probe.http_get ? toset([1]) : toset([])
 
               path = var.startup_probe.http_get.path
               port = var.startup_probe.http_get.port

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "service" {
         args  = var.args
 
         dynamic "startup_probe" {
-          for_each = length(var.startup_probe) > 0 ? [""] : []
+          for_each = var.startup_probe == null ? [] : [""]
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "service" {
         args  = var.args
 
         dynamic "startup_probe" {
-          for_each = var.startup_probe == {} ? toset([]) : toset([1])
+          for_each = var.startup_probe ? toset([]) : toset([1])
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds
@@ -83,7 +83,7 @@ resource "google_cloud_run_service" "service" {
             failure_threshold = var.startup_probe.failure_threshold
 
             dynamic "http_get" {
-              for_each = var.startup_probe.http_get == {} ? toset([]) : toset([1])
+              for_each = var.startup_probe.http_get ? toset([]) : toset([1])
 
               path = var.startup_probe.http_get.path
               port = var.startup_probe.http_get.port

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "service" {
         args  = var.args
 
         dynamic "startup_probe" {
-          for_each = var.startup_probe ? toset([1]) : toset([])
+          for_each = var.startup_probe != null ? toset([1]) : toset([])
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds
@@ -83,7 +83,7 @@ resource "google_cloud_run_service" "service" {
             failure_threshold = var.startup_probe.failure_threshold
 
             dynamic "http_get" {
-              for_each = var.startup_probe.http_get ? toset([1]) : toset([])
+              for_each = var.startup_probe.http_get != null ? toset([1]) : toset([])
 
               content {
                 path = var.startup_probe.http_get.path

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -78,9 +78,9 @@ resource "google_cloud_run_service" "service" {
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds
-            timeout_seconds = var.startup_probe.timeout_seconds
-            period_seconds = var.startup_probe.period_seconds
-            failure_threshold = var.startup_probe.failure_threshold
+            timeout_seconds       = var.startup_probe.timeout_seconds
+            period_seconds        = var.startup_probe.period_seconds
+            failure_threshold     = var.startup_probe.failure_threshold
 
             dynamic "http_get" {
               for_each = var.startup_probe.http_get != null ? toset([1]) : toset([])

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -85,8 +85,10 @@ resource "google_cloud_run_service" "service" {
             dynamic "http_get" {
               for_each = var.startup_probe.http_get ? toset([1]) : toset([])
 
-              path = var.startup_probe.http_get.path
-              port = var.startup_probe.http_get.port
+              content {
+                path = var.startup_probe.http_get.path
+                port = var.startup_probe.http_get.port
+              }
             }
           }
         }

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -73,22 +73,18 @@ resource "google_cloud_run_service" "service" {
         image = var.image
         args  = var.args
 
-        dynamic "startup_probe" {
-          count = var.startup_probe != null ? 1 : 0
+        startup_probe {
+          initial_delay_seconds = var.startup_probe.initial_delay_seconds
+          timeout_seconds       = var.startup_probe.timeout_seconds
+          period_seconds        = var.startup_probe.period_seconds
+          failure_threshold     = var.startup_probe.failure_threshold
 
-          content {
-            initial_delay_seconds = var.startup_probe.initial_delay_seconds
-            timeout_seconds       = var.startup_probe.timeout_seconds
-            period_seconds        = var.startup_probe.period_seconds
-            failure_threshold     = var.startup_probe.failure_threshold
+          dynamic "http_get" {
+            count = var.startup_probe.http_get != null ? 1 : 0
 
-            dynamic "http_get" {
-              count = var.startup_probe.http_get != null ? 1 : 0
-
-              content {
-                path = var.startup_probe.http_get.path
-                port = var.startup_probe.http_get.port
-              }
+            content {
+              path = var.startup_probe.http_get.path
+              port = var.startup_probe.http_get.port
             }
           }
         }

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -73,6 +73,7 @@ resource "google_cloud_run_service" "service" {
         image = var.image
         args  = var.args
 
+        # TODO: Implement tcp_socket and grpc configuration blocks
         dynamic "startup_probe" {
           for_each = var.startup_probe == null ? [] : [""]
 

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "service" {
         args  = var.args
 
         dynamic "startup_probe" {
-          for_each = var.startup_probe != null ? toset([1]) : toset([])
+          count = var.startup_probe != null ? 1 : 0
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds
@@ -83,7 +83,7 @@ resource "google_cloud_run_service" "service" {
             failure_threshold     = var.startup_probe.failure_threshold
 
             dynamic "http_get" {
-              for_each = var.startup_probe.http_get != null ? toset([1]) : toset([])
+              count = var.startup_probe.http_get != null ? 1 : 0
 
               content {
                 path = var.startup_probe.http_get.path

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -81,14 +81,14 @@ resource "google_cloud_run_service" "service" {
             timeout_seconds       = var.startup_probe.timeout_seconds
             period_seconds        = var.startup_probe.period_seconds
             failure_threshold     = var.startup_probe.failure_threshold
-          }
 
-          dynamic "http_get" {
-            for_each = var.startup_probe.http_get == null ? [] : [""]
+            dynamic "http_get" {
+              for_each = var.startup_probe.http_get == null ? [] : [""]
 
-            content {
-              path = var.startup_probe.http_get.path
-              port = var.startup_probe.http_get.port
+              content {
+                path = var.startup_probe.http_get.path
+                port = var.startup_probe.http_get.port
+              }
             }
           }
         }

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "service" {
         args  = var.args
 
         dynamic "startup_probe" {
-          for_each = var.startup_probe == null ? [] : [""]
+          for_each = length(var.startup_probe) > 0 ? [""] : []
 
           content {
             initial_delay_seconds = var.startup_probe.initial_delay_seconds

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -157,7 +157,7 @@ variable "startup_probe" {
     http_get = optional(object({
       path = optional(string)
       port = optional(number)
-    }), {})
+    }), null)
   })
   default     = {}
   description = "Optional startup probe configuration"

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -157,7 +157,7 @@ variable "startup_probe" {
     http_get = optional(object({
       path = optional(string)
       port = optional(number)
-    }), null)
+    }), {})
   })
   default     = {}
   description = "Optional startup probe configuration"

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -157,8 +157,8 @@ variable "startup_probe" {
     http_get = optional(object({
       path = optional(string)
       port = optional(number)
-    }))
+    }), null)
   })
-  default = {}
+  default = null
   description = "Optional startup probe configuration"
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -147,3 +147,17 @@ variable "additional_revision_annotations" {
   default     = {}
   description = "Annotations to add to the template.metadata.annotations field."
 }
+
+variable "startup_probe" {
+  type = object({
+    initial_delay_seconds = number
+    timeout_seconds = number
+    period_seconds = number
+    failure_threshold = number
+    http_get = object({
+      path = string
+      port = number
+    })
+  })
+  default = {}
+}

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -150,15 +150,14 @@ variable "additional_revision_annotations" {
 
 variable "startup_probe" {
   type = object({
-    initial_delay_seconds = optional(number)
-    timeout_seconds       = optional(number)
-    period_seconds        = optional(number)
-    failure_threshold     = optional(number)
+    initial_delay_seconds = optional(number, 0)
+    timeout_seconds       = optional(number, 1)
+    period_seconds        = optional(number, 10)
+    failure_threshold     = optional(number, 3)
     http_get = optional(object({
       path = optional(string)
       port = optional(number)
     }), null)
   })
-  default     = null
   description = "Optional startup probe configuration"
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -154,10 +154,10 @@ variable "startup_probe" {
     timeout_seconds = number
     period_seconds = number
     failure_threshold = number
-    http_get = object({
+    http_get = optional(object({
       path = optional(string)
       port = optional(number)
-    })
+    }))
   })
   default = {
     initial_delay_seconds = 0

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -155,9 +155,14 @@ variable "startup_probe" {
     period_seconds = number
     failure_threshold = number
     http_get = object({
-      path = string
-      port = number
+      path = optional(string)
+      port = optional(number)
     })
   })
-  default = {}
+  default = {
+    initial_delay_seconds = 0
+    timeout_seconds = 1
+    period_seconds = 10
+    failure_threshold = 3
+  }
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -159,5 +159,6 @@ variable "startup_probe" {
       port = optional(number)
     }), null)
   })
+  default     = {}
   description = "Optional startup probe configuration"
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -160,4 +160,5 @@ variable "startup_probe" {
     }))
   })
   default = {}
+  description = "Optional startup probe configuration"
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -150,19 +150,14 @@ variable "additional_revision_annotations" {
 
 variable "startup_probe" {
   type = object({
-    initial_delay_seconds = number
-    timeout_seconds = number
-    period_seconds = number
-    failure_threshold = number
+    initial_delay_seconds = optional(number)
+    timeout_seconds = optional(number)
+    period_seconds = optional(number)
+    failure_threshold = optional(number)
     http_get = optional(object({
       path = optional(string)
       port = optional(number)
     }))
   })
-  default = {
-    initial_delay_seconds = 0
-    timeout_seconds = 1
-    period_seconds = 10
-    failure_threshold = 3
-  }
+  default = {}
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -159,6 +159,6 @@ variable "startup_probe" {
       port = optional(number)
     }), null)
   })
-  default     = {}
+  default     = null
   description = "Optional startup probe configuration"
 }

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -155,8 +155,9 @@ variable "startup_probe" {
     period_seconds        = optional(number, 10)
     failure_threshold     = optional(number, 3)
     http_get = optional(object({
-      path = optional(string)
-      port = optional(number)
+      http_headers = optional(map(string), {})
+      path         = optional(string)
+      port         = optional(number)
     }), null)
   })
   default     = null

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -151,14 +151,14 @@ variable "additional_revision_annotations" {
 variable "startup_probe" {
   type = object({
     initial_delay_seconds = optional(number)
-    timeout_seconds = optional(number)
-    period_seconds = optional(number)
-    failure_threshold = optional(number)
+    timeout_seconds       = optional(number)
+    period_seconds        = optional(number)
+    failure_threshold     = optional(number)
     http_get = optional(object({
       path = optional(string)
       port = optional(number)
     }), null)
   })
-  default = null
+  default     = null
   description = "Optional startup probe configuration"
 }


### PR DESCRIPTION
This adds the capability to configure an HTTP startup probe for a Cloud Run service.