### PR TITLE
feat: Add HTTP liveness probe config to Cloud Run module

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -104,6 +104,36 @@ resource "google_cloud_run_service" "service" {
           }
         }
 
+        dynamic "liveness_probe" {
+          for_each = var.liveness_probe == null ? [] : [""]
+
+          content {
+            initial_delay_seconds = var.liveness_probe.initial_delay_seconds
+            timeout_seconds       = var.liveness_probe.timeout_seconds
+            period_seconds        = var.liveness_probe.period_seconds
+            failure_threshold     = var.liveness_probe.failure_threshold
+
+            dynamic "http_get" {
+              for_each = var.liveness_probe.http_get == null ? [] : [""]
+
+              content {
+                path = var.liveness_probe.http_get.path
+                port = var.liveness_probe.http_get.port
+
+                dynamic "http_headers" {
+                  for_each = (
+                    var.liveness_probe.http_get.http_headers
+                  )
+                  content {
+                    name  = http_headers.key
+                    value = http_headers.value
+                  }
+                }
+              }
+            }
+          }
+        }
+
         resources {
           requests = var.resources.requests
           limits   = var.resources.limits

--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -104,6 +104,7 @@ resource "google_cloud_run_service" "service" {
           }
         }
 
+        # TODO: Implement tcp_socket and grpc configuration blocks
         dynamic "liveness_probe" {
           for_each = var.liveness_probe == null ? [] : [""]
 

--- a/modules/cloud_run/variables.tf
+++ b/modules/cloud_run/variables.tf
@@ -163,3 +163,19 @@ variable "startup_probe" {
   default     = null
   description = "Optional startup probe configuration"
 }
+
+variable "liveness_probe" {
+  type = object({
+    initial_delay_seconds = optional(number, 0)
+    timeout_seconds       = optional(number, 1)
+    period_seconds        = optional(number, 10)
+    failure_threshold     = optional(number, 3)
+    http_get = optional(object({
+      http_headers = optional(map(string), {})
+      path         = optional(string)
+      port         = optional(number)
+    }), null)
+  })
+  default     = null
+  description = "Optional liveness probe configuration"
+}


### PR DESCRIPTION
This adds the capability to configure an HTTP liveness probe for a Cloud Run service.