### PR TITLE
Ignore the `status` field causing diffs

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -180,6 +180,7 @@ resource "google_cloud_run_service" "service" {
       metadata[0].labels["cloud.googleapis.com/location"],
       metadata[0].labels["commit-sha"],
       metadata[0].labels["managed-by"],
+      status,
       template[0].metadata[0].annotations["client.knative.dev/user-image"],
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],


### PR DESCRIPTION
This field just contains ephemeral runtime status that is changed by deployments and such. It doesnt belong in terraform state and shouldn't trigger a plan diff.