### PR TITLE
Ignore the "sha" label

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -180,6 +180,7 @@ resource "google_cloud_run_service" "service" {
       metadata[0].labels["cloud.googleapis.com/location"],
       metadata[0].labels["commit-sha"],
       metadata[0].labels["managed-by"],
+      metadata[0].labels["sha"],
       status,
       template[0].metadata[0].annotations["client.knative.dev/user-image"],
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],


### PR DESCRIPTION
This has been observed to change after deployment, perhaps due to CICD making updates.