### PR TITLE
Un-ignore the `status` field

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -181,7 +181,6 @@ resource "google_cloud_run_service" "service" {
       metadata[0].labels["commit-sha"],
       metadata[0].labels["managed-by"],
       metadata[0].labels["sha"],
-      status,
       template[0].metadata[0].annotations["client.knative.dev/user-image"],
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],


### PR DESCRIPTION
This was never a good idea last week when I added this line. It doesn't work because the `status` field is created by the provider logic and is therefore not ignorable (thanks Mike and Jonathan for helping with this).