### PR TITLE
Ignore `serving.knative.dev/nonce` which varies in prod

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -188,6 +188,7 @@ resource "google_cloud_run_service" "service" {
       template[0].metadata[0].annotations["serving.knative.dev/lastModifier"],
       template[0].metadata[0].labels["run.googleapis.com/startupProbeType"],
       template[0].metadata[0].labels["client.knative.dev/nonce"],
+      template[0].metadata[0].labels["serving.knative.dev/nonce"],
       template[0].metadata[0].labels["sha"],
       template[0].spec[0].containers[0].image,
     ]


### PR DESCRIPTION
We observed spurious terraform diffs due to this label being changed by deployment automation